### PR TITLE
use GITHUB_OUTPUT file command

### DIFF
--- a/commit-and-create-pr.sh
+++ b/commit-and-create-pr.sh
@@ -122,9 +122,9 @@ PR_URL=$(gh pr create --title "${INPUT_TITLE:-$INPUT_COMMIT_MESSAGE}" --body-fil
 if [[ -f "${GITHUB_OUTPUT:-}" ]]; then
 cat <<__END_OF_OUTPUT__ >> "$GITHUB_OUTPUT"
 commit-url=$COMMIT_URL
-name=pr-url::$PR_URL
+pr-url=$PR_URL
 __END_OF_OUTPUT__
 else
 echo "::set-output name=commit-url::$COMMIT_URL"
-echo "::set-output name=commit-url::$COMMIT_URL"
+echo "::set-output name=pr-url::$PR_URL"
 fi

--- a/commit-and-create-pr.sh
+++ b/commit-and-create-pr.sh
@@ -102,8 +102,6 @@ if [[ ${RUNNER_DEBUG:-} = '1' ]]; then
 fi
 COMMIT_URL=$(gh api graphql --input "$TMPDIR/query-create-commit.txt" --jq '.data.createCommitOnBranch.commit.url')
 
-echo "::set-output name=commit-url::$COMMIT_URL"
-
 git reset HEAD > /dev/null 2>&1
 
 cat <<__END_OF_BODY__ > "$TMPDIR/pr-body.txt"
@@ -120,4 +118,13 @@ if [[ ${RUNNER_DEBUG:-} = '1' ]]; then
 fi
 
 PR_URL=$(gh pr create --title "${INPUT_TITLE:-$INPUT_COMMIT_MESSAGE}" --body-file "$TMPDIR/pr-body.txt" --base "$INPUT_BASE_BRANCH" --head "$INPUT_HEAD_BRANCH")
-echo "::set-output name=pr-url::$PR_URL"
+
+if [[ -f "${GITHUB_OUTPUT:-}" ]]; then
+cat <<__END_OF_OUTPUT__ >> "$GITHUB_OUTPUT"
+commit-url=$COMMIT_URL
+name=pr-url::$PR_URL
+__END_OF_OUTPUT__
+else
+echo "::set-output name=commit-url::$COMMIT_URL"
+echo "::set-output name=commit-url::$COMMIT_URL"
+fi


### PR DESCRIPTION
`set-output` command is now deprecated. we should migrate to the file commands

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/